### PR TITLE
CVE-2016-5636

### DIFF
--- a/database/java/2016/9878.yaml
+++ b/database/java/2016/9878.yaml
@@ -1,0 +1,18 @@
+cve: 2016-9878
+title: "Directory Traversal in the Spring Framework ResourceServlet"
+description: >
+    Paths provided to the ResourceServlet were not properly sanitized and as a result exposed to directory traversal attacks.
+cvss_v2: 5.0
+references:
+    - https://pivotal.io/security/cve-2016-9878
+affected:
+    - groupId: "org.springframework"
+      artifactId: "spring"
+      version:
+        - "<=3.2.17.RELEASE"
+        - "<=4.2.8.RELEASE"
+        - "<=4.3.4.RELEASE"
+      fixedin:
+        - ">=3.2.18.RELEASE"
+        - ">=4.2.9.RELEASE"
+        - ">=4.3.5.RELEASE"

--- a/database/java/2016/9879.yaml
+++ b/database/java/2016/9879.yaml
@@ -1,0 +1,18 @@
+cve: 2016-9879
+title: "Encoded \"/\" in path variables"
+description: >
+    Spring Security does not consider URL path parameters when processing security constraints. By adding a URL path parameter with an encoded "/" to a request, an attacker may be able to bypass a security constraint[refer to link for full details]
+cvss_v2: 5.0
+references:
+    - https://pivotal.io/security/cve-2016-9879
+affected:
+    - groupId: "org.springframework.security"
+      artifactId: "spring-security-core"
+      version:
+        - "<=3.2.9.RELEASE"
+        - "<=4.1.3.RELEASE"
+        - "<=4.2.0.RELEASE"
+      fixedin:
+        - ">=3.2.10.RELEASE"
+        - ">=4.1.4.RELEASE"
+        - ">=4.2.1.RELEASE"


### PR DESCRIPTION

cve: CVE-2016-5636
title: Integer overflow in the get_data function in zipimport.c in CPython
description: >
    Integer overflow in the get_data function in zipimport.c in CPython (aka Python) before 2.7.12, 3.x before 3.4.5, and 3.5.x before 3.5.2 allows remote attackers to have unspecified impact via a negative data size value, which triggers a heap-based buffer overflow.	
cvss_v2: 10.0
references:
    - https://bugs.python.org/issue26171
    - https://hg.python.org/cpython/raw-file/v2.7.12/Misc/NEWS
    - https://docs.python.org/3.5/whatsnew/changelog.html#python-3-5-2
    - http://www.securityfocus.com/bid/91247
affected:
    - name: Python
      version:
        - "<=2.7.12"